### PR TITLE
T02: Add comprehensive dependency graph and architectural analysis

### DIFF
--- a/docs_agents/PROMPT.md
+++ b/docs_agents/PROMPT.md
@@ -129,8 +129,19 @@ important_files:
   - web/pom.xml
   - web/src/main/ng/package.json
   - web/src/main/ng/tsconfig.json
+  - web/src/main/ng/angular.json          # Angular build konfigurace (production profily, optimalizace)
+  - web/src/main/webapp/META-INF/context.xml  # Tomcat deployment descriptor
   - ThumbnailsGenerator/pom.xml
   # docker-compose soubory nejsou součástí tohoto repozitáře
+
+known_facts:
+  xslt_processor: "Saxon"
+  saxon_version: "8.7"                    # kriticky zastaralý; cílová verze Saxon-HE 12.x
+  java_version_web: "17"
+  java_version_thumbnails: "1.8"          # nekonzistentní s hlavní aplikací
+  jakarta_ee_version: "11.0.0"            # všechny závislosti musí používat jakarta.* namespace
+  angular_version: "21"
+  solr_client_version: "9.10.1"           # musí odpovídat verzi Solr serveru
 
 ignored_directories:
   - .git
@@ -293,8 +304,10 @@ Analyze:
 Detect:
 
 - tightly coupled Java modules
-- modules with excessive responsibilities
-- outdated dependencies (versions)
+- Java classes with excessive responsibilities (god classes — LOC > 500; map their internal deps)
+- outdated or end-of-life (EOL) dependencies — flag if project has no security updates since > 2 years
+- Maven dependencies using `javax.*` namespace in a Jakarta EE project (expect `jakarta.*`)
+- Maven dependencies with version ranges (e.g. `[0.4,0.5)`) — non-deterministic build risk
 - missing or redundant test dependencies
 
 Record architectural issues in `refactoring_backlog.md`.
@@ -338,6 +351,8 @@ Detect:
 - missing field type optimisations (e.g. `docValues` on sort fields)
 - inconsistencies between the Java model and the Solr schema
 - schema changes that would require reindexation without a migration note
+- mismatch between `solr-solrj` client version (known_facts.solr_client_version) and the Solr
+  server version declared in configuration or Docker files
 
 Record severe issues in `bugs.md`.
 
@@ -386,7 +401,9 @@ Detect:
 - transformations without a header comment (purpose, input namespace)
 - hardcoded values tightly coupled to the current AMČR API response structure
 - missing namespace declarations or inconsistent prefixes
-- XSLT 1.0 patterns that could be replaced with XSLT 2.0 / 3.0 constructs
+- XSLT 1.0 patterns that could be replaced with XSLT 2.0 / 3.0 constructs; note that the
+  current processor (Saxon known_facts.saxon_version) may not support all XSLT 3.0 features —
+  flag any XSLT 3.0 constructs already used as incompatible with the deployed processor
 - duplicated named templates that could be extracted to a shared file
 - transformations lacking test fixtures
 

--- a/docs_agents/bugs.md
+++ b/docs_agents/bugs.md
@@ -9,4 +9,26 @@
 
 ---
 
+### BUG-001: Saxon 8.7 — kriticky zastaralý XSLT procesor bez bezpečnostních záplat
+
+- **Soubor:** `web/pom.xml:125`
+- **Závažnost:** Vysoká
+- **GitHub Issue:** nový kandidát na issue
+- **Popis:** Maven závislost `net.sf.saxon:saxon:8.7` pochází z roku 2006 (cca 18 let stará verze). Aktuální open-source verze je Saxon-HE 12.x. Absence bezpečnostních záplat za 18 let vývoje představuje bezpečnostní riziko při zpracování vstupního XML z Fedora API. AGENTS.md deklaruje použití XSLT 2.0/3.0 procesoru, ale Saxon 8.7 XSLT 3.0 nepodporuje a má jen částečnou XSLT 2.0 podporu.
+- **Navrhovaná oprava:** Nahradit závislost za `net.sf.saxon:Saxon-HE:12.5` (open-source, zpětně kompatibilní pro XSLT 2.0, plná XSLT 3.0 podpora). Po upgradu ověřit existující XSLT transformace.
+- **Task:** T02
+
+---
+
+### BUG-002: javax.mail namespace nekompatibilní s Jakarta EE 11
+
+- **Soubor:** `web/pom.xml:78`
+- **Závažnost:** Střední
+- **GitHub Issue:** nový kandidát na issue
+- **Popis:** Závislost `javax.mail:mail:1.4.7` používá starý `javax` namespace. Projekt cílí na Jakarta EE 11, která používá `jakarta.*` namespace. Na moderních application serverech (Tomcat 10+, WildFly 27+) může dojít ke classloading konfliktu nebo nefunkčnímu odesílání e-mailů.
+- **Navrhovaná oprava:** Nahradit za `jakarta.mail:jakarta.mail-api` + implementaci (Angus Mail: `org.eclipse.angus:angus-mail`). Aktualizovat i `org.apache.commons:commons-email`, který staví na javax.mail.
+- **Task:** T02
+
+---
+
 <!-- Záznamy přidávají agenti po dokončení jednotlivých tasků -->

--- a/docs_agents/dependency_graph.json
+++ b/docs_agents/dependency_graph.json
@@ -1,1 +1,400 @@
-{}
+{
+  "_meta": {
+    "task_id": "T02",
+    "generated_at": "2026-03-08",
+    "description": "Graf interních a externích závislostí (Maven + npm) — Digitální archiv AMČR"
+  },
+
+  "java_packages": {
+    "root": {
+      "package": "cz.inovatika.arup.digiarchiv.web4",
+      "description": "Hlavní balíček — servlety, konfigurace, pomocné třídy",
+      "files": [
+        "ApiServlet.java", "AppState.java", "AuthService.java",
+        "ConfigServlet.java", "FavoritesServlet.java", "FeedbackServlet.java",
+        "FormatUtils.java", "GPSconvertor.java", "HandleServlet.java",
+        "I18n.java", "I18nServlet.java", "ImageServlet.java",
+        "InitServlet.java", "LogAnalytics.java", "LoginServlet.java",
+        "Options.java", "PdfServlet.java", "SearchServlet.java", "TextsServlet.java"
+      ],
+      "key_classes": {
+        "SearchServlet": {
+          "lines": 634,
+          "responsibility": "HTTP servlet pro vyhledávání — centrální vstupní bod pro všechny dotazy",
+          "severity": "god_class",
+          "internal_deps": [
+            "index.SearchUtils", "index.SolrSearcher", "index.ComponentSearcher",
+            "index.EntitySearcher", "index.PIANSearcher", "fedora.models.Uzivatel"
+          ]
+        },
+        "Options": {
+          "lines": 276,
+          "responsibility": "Singleton konfigurace — načítá a slučuje JSON konfiguraci ze souborů",
+          "issues": ["singleton_global_state", "potential_concurrency_issues"],
+          "internal_deps": []
+        },
+        "InitServlet": {
+          "lines": 192,
+          "responsibility": "Lifecycle servlet — inicializace I18n, Solr klientů, temp adresářů",
+          "internal_deps": ["index.SolrClientFactory"]
+        },
+        "AuthService": {
+          "lines": 82,
+          "responsibility": "Autentizace uživatelů přes externí AMČR API",
+          "internal_deps": ["Options", "fedora.FedoraModel", "fedora.models.Uzivatel"]
+        },
+        "AppState": {
+          "lines": 60,
+          "responsibility": "Throttling stahování souborů per-IP",
+          "internal_deps": ["Options"]
+        }
+      }
+    },
+    "fedora": {
+      "package": "cz.inovatika.arup.digiarchiv.web4.fedora",
+      "description": "Komunikace s Fedora Repository REST API — harvestování a modely",
+      "files": ["FedoraHarvester.java", "FedoraModel.java", "FedoraServlet.java", "FedoraUtils.java"],
+      "key_classes": {
+        "FedoraHarvester": {
+          "lines": 1024,
+          "responsibility": "Harvestuje záznamy z Fedory a indexuje je do Solru",
+          "severity": "god_class",
+          "internal_deps": [
+            "FormatUtils", "InitServlet", "Options",
+            "index.IndexUtils", "index.SolrClientFactory", "index.SolrSearcher"
+          ]
+        },
+        "FedoraUtils": {
+          "lines": 124,
+          "responsibility": "HTTP klient pro Fedora API — autorizace, stahování souborů",
+          "internal_deps": ["Options"]
+        }
+      }
+    },
+    "fedora.models": {
+      "package": "cz.inovatika.arup.digiarchiv.web4.fedora.models",
+      "description": "Datové modely AMČR entit (Akce, Dokument, Projekt, Lokalita, atd.)",
+      "file_count": 37,
+      "note": "Modely jsou hydratovány z JSON odpovědí Fedory; nemají interní cross-závislosti (čisté POJO)"
+    },
+    "index": {
+      "package": "cz.inovatika.arup.digiarchiv.web4.index",
+      "description": "Solr indexování a vyhledávání — SolrSearcher, IndexUtils, SearchUtils, speciální Searcher třídy",
+      "file_count": 22,
+      "key_classes": {
+        "SolrSearcher": {
+          "lines": 1048,
+          "responsibility": "Centrální Solr dotazovací třída — správa přístupových úrovní, facety, thesaurus",
+          "severity": "god_class",
+          "internal_deps": ["LoginServlet", "Options"]
+        },
+        "SearchUtils": {
+          "lines": 344,
+          "responsibility": "Factory a utility pro vyhledávání — instantiace Searcher tříd, CSV/JSON konverze",
+          "issues": ["massive_switch_statements", "hardcoded_entity_type_mappings"],
+          "internal_deps": ["Options", "fedora.FedoraHarvester"]
+        },
+        "IndexUtils": {
+          "lines": 296,
+          "responsibility": "Utility pro manipulaci Solr dokumentů — přidávání polí, bezpečnostní přípony",
+          "internal_deps": [
+            "Options", "fedora.FedoraUtils",
+            "fedora.models.Historie", "fedora.models.Lang", "fedora.models.Vocab"
+          ]
+        }
+      }
+    },
+    "imagging": {
+      "package": "cz.inovatika.arup.digiarchiv.web4.imagging",
+      "description": "Práce s obrazovými soubory — přístup, typy MIME, PDF",
+      "note": "PŘEKLEP v názvu balíčku — mělo by být 'imaging'",
+      "files": ["ImageAccess.java", "ImageMimeType.java", "ImageSupport.java", "PDFAcceptor.java"]
+    },
+    "oai": {
+      "package": "cz.inovatika.arup.digiarchiv.web4.oai",
+      "description": "OAI-PMH protokol — výdej metadat pro sklízeče",
+      "files": ["OAIRequest.java", "OAIServlet.java"]
+    }
+  },
+
+  "maven_dependencies": {
+    "java_version": "17",
+    "jakarta_ee_version": "11.0.0",
+    "scope_compile": [
+      {
+        "artifact": "com.jayway.jsonpath:json-path:2.10.0",
+        "purpose": "JSONPath dotazy nad JSON daty"
+      },
+      {
+        "artifact": "commons-io:commons-io:2.21.0",
+        "purpose": "Souborové operace, IOUtils"
+      },
+      {
+        "artifact": "org.json:json:20251224",
+        "purpose": "JSON parsování a serializace"
+      },
+      {
+        "artifact": "commons-codec:commons-codec:1.21.0",
+        "purpose": "Base64, hash utility"
+      },
+      {
+        "artifact": "org.apache.xmlrpc:xmlrpc-client:3.1.3",
+        "purpose": "XML-RPC klient",
+        "concern": "EOL_DEPENDENCY — Apache XML-RPC je end-of-life od 2016; zvážit odstranění nebo náhradu"
+      },
+      {
+        "artifact": "org.apache.httpcomponents:httpclient:4.5.14",
+        "purpose": "HTTP klient (starší Apache HttpClient 4.x)",
+        "concern": "OUTDATED — projekt jinak používá java.net.http (JDK 11+); zvážit sjednocení na jeden HTTP klient"
+      },
+      {
+        "artifact": "org.apache.pdfbox:pdfbox:3.0.6",
+        "purpose": "PDF zpracování a generování"
+      },
+      {
+        "artifact": "org.apache.commons:commons-csv:1.14.1",
+        "purpose": "CSV export výsledků"
+      },
+      {
+        "artifact": "org.apache.commons:commons-lang3:3.18.0",
+        "purpose": "Pomocné utility pro řetězce"
+      },
+      {
+        "artifact": "javax.mail:mail:1.4.7",
+        "purpose": "Odesílání e-mailů (feedback formulář)",
+        "concern": "NAMESPACE_MISMATCH — používá starý javax.mail namespace; Jakarta EE 11 vyžaduje jakarta.mail. Nutno ověřit kompatibilitu s application serverem."
+      },
+      {
+        "artifact": "org.apache.commons:commons-email:1.6.0",
+        "purpose": "Wrapper pro odesílání e-mailů nad javax.mail"
+      },
+      {
+        "artifact": "org.apache.commons:commons-text:1.15.0",
+        "purpose": "StringEscapeUtils, textové utility"
+      },
+      {
+        "artifact": "com.fasterxml.jackson:jackson-bom:2.21.0",
+        "purpose": "BOM pro Jackson verze"
+      },
+      {
+        "artifact": "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.21.0",
+        "purpose": "XML → Java object binding"
+      },
+      {
+        "artifact": "org.locationtech.jts.io:jts-io-common:1.20.0",
+        "purpose": "WKT/WKB geometrie pro prostorové dotazy"
+      },
+      {
+        "artifact": "org.apache.solr:solr-solrj:9.10.1",
+        "purpose": "Solr Java klient"
+      },
+      {
+        "artifact": "net.sf.saxon:saxon:8.7",
+        "purpose": "XSLT procesor",
+        "concern": "KRITICKY_ZASTARALE — Saxon 8.7 vydán v roce 2006. Aktuální verze je Saxon-HE 12.x. Chybí ~18 let bezpečnostních záplat. AGENTS.md dokumentuje XSLT 2.0/3.0, ale Saxon 8.7 plně XSLT 3.0 nepodporuje."
+      }
+    ],
+    "scope_provided": [
+      {
+        "artifact": "jakarta.platform:jakarta.jakartaee-api:11.0.0",
+        "purpose": "Jakarta EE API (poskytuje application server)"
+      }
+    ],
+    "scope_test": [],
+    "maven_plugins": [
+      "org.codehaus.mojo:exec-maven-plugin:3.6.3 — spouští npm build",
+      "maven-clean-plugin:3.5.0 — čistí Angular výstup",
+      "maven-resources-plugin:3.4.0 — kopíruje Angular dist do webapp",
+      "com.coderplus.maven.plugins:copy-rename-maven-plugin:1.0.1 — přejmenování index.csr.html",
+      "com.google.code.maven-replacer-plugin:replacer:1.5.3 — vkládá JSP pageEncoding a context name",
+      "maven-compiler-plugin:3.15.0 — Java 17 source/target",
+      "maven-war-plugin:3.5.1 — balení WAR"
+    ],
+    "version_management_note": "Verze závislostí jsou spravovány přímo v pom.xml bez parent POM ani BOM. Neexistuje centralizovaná správa verzí mezi moduly."
+  },
+
+  "thumbnails_generator_dependencies": {
+    "java_version": "1.8",
+    "concern": "OUTDATED — ThumbnailsGenerator kompiluje pro Java 1.8, zatímco hlavní aplikace cílí na Java 17.",
+    "dependencies": [
+      "com.twelvemonkeys.imageio:imageio-tiff:3.13.0",
+      "com.twelvemonkeys.imageio:imageio-jpeg:3.13.0",
+      "com.github.jai-imageio:jai-imageio-jpeg2000:1.4.0",
+      "org.apache.pdfbox:pdfbox:3.0.6",
+      "commons-io:commons-io:2.21.0",
+      "org.json:json:20251224",
+      "org.apache.solr:solr-solrj:9.10.1",
+      "net.coobird:thumbnailator:[0.4,0.5) — range verze, nedeterministický build",
+      "org.slf4j:slf4j-simple:2.0.17",
+      "com.levigo.jbig2:levigo-jbig2-imageio:2.0"
+    ],
+    "shared_with_web_module": ["pdfbox:3.0.6", "commons-io:2.21.0", "org.json:20251224", "solr-solrj:9.10.1"],
+    "note": "Bez společného parent POM — verze sdílených závislostí musí být synchronizovány ručně."
+  },
+
+  "npm_dependencies": {
+    "angular_version": "21.1.x",
+    "typescript_version": "~5.9.3",
+    "production_count": 25,
+    "production": {
+      "@angular/*": "^21.1.x — core framework, routing, forms, Material, SSR",
+      "@bluehalo/ngx-leaflet": "^21.0.0 — Leaflet mapa v Angular",
+      "@bluehalo/ngx-leaflet-markercluster": "^21.0.0 — shlukování markerů",
+      "@ngu/carousel": "^20.0.1 — carousel komponenta (pro Angular 20, app je Angular 21)",
+      "@ngx-translate/core": "^17.0.0 — i18n překlady",
+      "axios": "^1.11.0 — HTTP klient (nadbytečný vedle Angular HttpClient)",
+      "echarts": "^6.0.0 — grafy/vizualizace",
+      "express": "^5.1.0 — SSR server",
+      "heatmap.js": "^2.0.5 — heatmapa",
+      "leaflet": "^1.9.4 — mapová knihovna",
+      "leaflet.locationfilter": "^0.1.0 — filtrování polohy (verze 0.x, neudržovaný?)",
+      "moment": "^2.30.1 — práce s datem (v maintenance mode od 2020)",
+      "ng-recaptcha-2": "^21.0.1 — reCAPTCHA",
+      "ngx-echarts": "^21.0.0 — wrapper Apache ECharts",
+      "rxjs": "~7.8.0 — reaktivní programování",
+      "wicket": "^1.3.8 — WKT/WKB parsování"
+    },
+    "devDependencies": {
+      "jasmine-core": "~6.0.1",
+      "karma": "~6.4.0",
+      "typescript": "~5.9.3"
+    },
+    "concerns": [
+      {
+        "dependency": "axios:^1.11.0",
+        "issue": "REDUNDANT — Angular HttpClient pokrývá potřeby HTTP; axios zvyšuje bundle size"
+      },
+      {
+        "dependency": "@ngu/carousel:^20.0.1",
+        "issue": "VERSION_MISMATCH — carousel je pro Angular 20, aplikace používá Angular 21"
+      },
+      {
+        "dependency": "moment:^2.30.1",
+        "issue": "LEGACY — Moment.js je v maintenance mode. Doporučena migrace na date-fns nebo nativní Angular DatePipe"
+      },
+      {
+        "dependency": "leaflet.locationfilter:^0.1.0",
+        "issue": "NEUDRZOVANY — verze 0.1.0; ověřit aktivitu projektu"
+      }
+    ]
+  },
+
+  "docker_service_dependencies": {
+    "note": "Docker a docker-compose soubory nejsou součástí tohoto repozitáře (zjištěno v T01). Závislosti mezi službami nelze z tohoto repozitáře analyzovat."
+  },
+
+  "external_dependencies": {
+    "amcr_api": {
+      "name": "AMČR (aiscr-webamcr)",
+      "description": "Zdrojový systém archeologických dat",
+      "protocol": "Fedora Repository REST API",
+      "access_pattern": "HTTP polling / harvestování",
+      "authentication": "Basic auth nebo Bearer token (FedoraUtils.java)",
+      "data_format": "JSON (primárně), XML (XSLT transformace)",
+      "coupling": "Vysoká — FedoraHarvester, FedoraUtils a všechny modely v fedora.models jsou přímo svázány s datovým modelem AMČR API. Změna API verze vyžaduje úpravy v mnoha souborech.",
+      "version_negotiation": "XSLT transformace pro konverzi mezi verzemi 2.0, 2.1, 2.2"
+    },
+    "solr": {
+      "name": "Apache Solr",
+      "version_client": "9.10.1 (solr-solrj)",
+      "access_pattern": "SolrJ klient — HTTP/JSON",
+      "coupling": "Vysoká — SolrSearcher (1048 ř.), IndexUtils, FedoraHarvester"
+    },
+    "fedora_repository": {
+      "name": "Fedora Repository",
+      "role": "Úložiště digitálních objektů a binárních souborů",
+      "access": "REST API přes FedoraUtils"
+    },
+    "google_recaptcha": {
+      "name": "Google reCAPTCHA",
+      "role": "Ochrana formulářů",
+      "frontend": "ng-recaptcha-2"
+    }
+  },
+
+  "architectural_issues": [
+    {
+      "id": "ARCH-01",
+      "title": "God třídy: SolrSearcher a FedoraHarvester",
+      "severity": "Vysoká",
+      "description": "SolrSearcher má 1 048 řádků, FedoraHarvester má 1 024 řádků. Obě třídy mají nadměrné množství zodpovědností.",
+      "affected_files": [
+        "web/src/main/java/cz/inovatika/arup/digiarchiv/web4/index/SolrSearcher.java",
+        "web/src/main/java/cz/inovatika/arup/digiarchiv/web4/fedora/FedoraHarvester.java"
+      ],
+      "recommendation": "Refaktoring na menší třídy (Command pattern, Strategy pattern)"
+    },
+    {
+      "id": "ARCH-02",
+      "title": "Saxon 8.7 — kriticky zastaralý XSLT procesor",
+      "severity": "Vysoká",
+      "description": "Saxon 8.7 z roku 2006 je kriticky zastaralý. Aktuální verze je Saxon-HE 12.x. ~18 let chybějících bezpečnostních záplat.",
+      "affected_files": ["web/pom.xml"],
+      "recommendation": "Upgradovat na Saxon-HE 12.x (XSLT 3.0 podpora, aktivní vývoj)"
+    },
+    {
+      "id": "ARCH-03",
+      "title": "javax.mail v Jakarta EE 11 projektu",
+      "severity": "Střední",
+      "description": "javax.mail:1.4.7 používá starý javax namespace. Jakarta EE 11 vyžaduje jakarta.mail. Možný classloading konflikt.",
+      "affected_files": ["web/pom.xml"],
+      "recommendation": "Nahradit jakarta.mail:jakarta.mail-api + Angus Mail implementace"
+    },
+    {
+      "id": "ARCH-04",
+      "title": "EOL závislost: Apache XML-RPC",
+      "severity": "Střední",
+      "description": "org.apache.xmlrpc:xmlrpc-client:3.1.3 — end-of-life od roku 2016, bez bezpečnostních aktualizací.",
+      "affected_files": ["web/pom.xml"],
+      "recommendation": "Nahradit REST klientem (java.net.http)"
+    },
+    {
+      "id": "ARCH-05",
+      "title": "ThumbnailsGenerator cílí na Java 1.8",
+      "severity": "Střední",
+      "description": "Hlavní aplikace cílí na Java 17, ThumbnailsGenerator na Java 1.8.",
+      "affected_files": ["ThumbnailsGenerator/pom.xml"],
+      "recommendation": "Upgradovat ThumbnailsGenerator na Java 17+"
+    },
+    {
+      "id": "ARCH-06",
+      "title": "Axios vs Angular HttpClient — duplicita",
+      "severity": "Nízká",
+      "description": "Frontend obsahuje axios i Angular HttpClient. Dva HTTP klienty zvyšují bundle size.",
+      "affected_files": ["web/src/main/ng/package.json"],
+      "recommendation": "Ověřit využití axios a migrovat na Angular HttpClient"
+    },
+    {
+      "id": "ARCH-07",
+      "title": "Moment.js v maintenance mode",
+      "severity": "Nízká",
+      "description": "Moment.js je od roku 2020 v maintenance mode.",
+      "affected_files": ["web/src/main/ng/package.json"],
+      "recommendation": "Migrovat na date-fns nebo nativní Angular DatePipe"
+    },
+    {
+      "id": "ARCH-08",
+      "title": "Range verze pro thumbnailator",
+      "severity": "Nízká",
+      "description": "net.coobird:thumbnailator:[0.4,0.5) — nedeterministický build.",
+      "affected_files": ["ThumbnailsGenerator/pom.xml"],
+      "recommendation": "Zafixovat konkrétní verzi (např. 0.4.20)"
+    },
+    {
+      "id": "ARCH-09",
+      "title": "Žádný parent POM ani BOM",
+      "severity": "Střední",
+      "description": "Sdílené závislosti musí být synchronizovány ručně mezi web/ a ThumbnailsGenerator/.",
+      "affected_files": ["web/pom.xml", "ThumbnailsGenerator/pom.xml"],
+      "recommendation": "Přidat root parent POM s dependencyManagement"
+    },
+    {
+      "id": "ARCH-10",
+      "title": "Žádné automatizované Java testy",
+      "severity": "Vysoká",
+      "description": "Adresář web/src/test neexistuje. Již evidováno v refactoring_backlog (T01).",
+      "affected_files": ["web/"],
+      "recommendation": "Přidat JUnit 5 testy pro klíčové třídy"
+    }
+  ]
+}

--- a/docs_agents/prompt_evolution/T02_prompt_update.md
+++ b/docs_agents/prompt_evolution/T02_prompt_update.md
@@ -1,0 +1,44 @@
+# T02 — Návrhy na zlepšení promptu
+
+**Task:** T02 — Graf interních a externích závislostí
+**Datum:** 2026-03-08
+
+---
+
+## Co v promptu chybělo / bylo nejasné
+
+1. **Hloubka analýzy interních závislostí:** Prompt zadává analýzu Java package dependencies, ale neurčuje, zda stačí na úrovni balíčků nebo je potřeba mapovat konkrétní třídy. Bylo by užitečné explicitně požadovat analýzu god tříd (LOC > 500) a jejich interních vazeb.
+
+2. **Sledování EOL závislostí:** Prompt neurequiruje explicitní kontrolu EOL stavu závislostí. Doporučuji přidat pokyn: *"Pro každou Maven/npm závislost ověř, zda projekt není end-of-life (EOL) nebo v maintenance mode."*
+
+3. **Namespace kompatibilita Jakarta EE:** Projekt cílí na Jakarta EE 11, ale tato skutečnost není v T02 sekci zohledněna. Doporučuji přidat instrukci: *"Ověřit, zda všechny Maven závislosti používají `jakarta.*` namespace (ne starý `javax.*`) v souladu s deklarovanou Jakarta EE verzí."*
+
+4. **Version range závislosti:** Prompt neřeší detekci nedeterministických range verzí v Maven (typ `[0.4,0.5)`). Doporučuji přidat: *"Označit závislosti s range verzemi jako rizikové pro reprodukovatelnost buildu."*
+
+---
+
+## Co by příštímu agentovi pomohlo
+
+1. **Přidat do known_facts v review_config.yaml:**
+   - `saxon_version: "8.7"` — kriticky zastaralý, cílová verze `Saxon-HE 12.x`
+   - `jakarta_ee_version: "11.0.0"` — všechny závislosti musí používat `jakarta.*` namespace
+   - `java_version: "17"` — hlavní aplikace; ThumbnailsGenerator stále na Java 1.8
+
+2. **Sekce T03 (Solr):** Při analýze Solr schémat ověřit soulad s `solr-solrj:9.10.1` — verze klienta musí odpovídat verzi Solr serveru.
+
+3. **Sekce T04 (XSLT):** Při analýze XSLT souborů ověřit, zda soubory využívají konstrukty XSLT 3.0 (které Saxon 8.7 nepodporuje) — pokud ano, upgrade Saxon je urgentní.
+
+---
+
+## Jaké soubory nebo adresáře by stálo za to přidat do known_facts / important_files
+
+- `web/src/main/ng/angular.json` — build konfigurace Angular (production/development profily, optimalizace)
+- `web/src/main/ng/tsconfig.json` — TypeScript strict mode nastavení
+- `web/src/main/webapp/META-INF/context.xml` — deployment descriptor pro Tomcat
+
+---
+
+## Poznámky k procesu
+
+- Analýza Java interních závislostí byla provedena čtením import sekcí klíčových tříd — automatizace přes `jdeps` by byla efektivnější.
+- Saxon verze 8.7 je uvedena v pom.xml jako `net.sf.saxon:saxon` (starý Maven artifactId); novější verze Saxon-HE mají artifactId `net.sf.saxon:Saxon-HE`.

--- a/docs_agents/refactoring_backlog.md
+++ b/docs_agents/refactoring_backlog.md
@@ -9,7 +9,17 @@
 
 <!-- Architektonické problémy, bezpečnostní dluhy, Solr výkon -->
 
-### [T01] Absence automatizovaných testů
+### [T02] Saxon 8.7 — kriticky zastaralý XSLT procesor
+- **Zjištění:** `net.sf.saxon:saxon:8.7` (vydán 2006) — aktuální je Saxon-HE 12.x. Chybí ~18 let bezpečnostních záplat.
+- **Dopad:** Bezpečnostní riziko; Saxon 8.7 nepodporuje XSLT 3.0 (rozpor s AGENTS.md).
+- **Návrh:** Upgradovat na `net.sf.saxon:Saxon-HE:12.5`; ověřit kompatibilitu existujících XSLT.
+
+### [T02] God třídy: SolrSearcher (1 048 ř.) a FedoraHarvester (1 024 ř.)
+- **Zjištění:** Obě třídy mají nadměrné zodpovědnosti (query building, access control, HTTP komunikace, transformace dat vše pohromadě).
+- **Dopad:** Nízká testovatelnost, vysoká komplexita změn, riziko regresí.
+- **Návrh:** Extrahovat zodpovědnosti do specializovaných tříd (Strategy/Command pattern).
+
+### [T02] Absence automatizovaných testů
 - **Zjištění:** Adresář `web/src/test` neexistuje. Projekt nemá žádné automatizované Java testy.
 - **Dopad:** Regresní změny nelze automaticky odhalit; CI pipeline nemůže ověřit správnost kódu.
 - **Návrh:** Přidat unit testy pro SearchUtils, IndexUtils, FormatUtils, FedoraUtils.
@@ -18,6 +28,31 @@
 ## Střední priorita
 
 <!-- Optimalizace, XSLT refaktoring, Docker build -->
+
+### [T02] javax.mail v Jakarta EE 11 projektu
+- **Zjištění:** `javax.mail:mail:1.4.7` používá starý `javax` namespace; Jakarta EE 11 očekává `jakarta.mail`.
+- **Dopad:** Možný classloading konflikt na moderním application serveru (Tomcat 11+, WildFly 27+).
+- **Návrh:** Nahradit `jakarta.mail:jakarta.mail-api` + Angus Mail implementace.
+
+### [T02] EOL závislost: Apache XML-RPC
+- **Zjištění:** `org.apache.xmlrpc:xmlrpc-client:3.1.3` — end-of-life od roku 2016.
+- **Dopad:** Bez bezpečnostních aktualizací; zbytečná závislost.
+- **Návrh:** Identifikovat použití v kódu a nahradit `java.net.http`.
+
+### [T02] Žádný parent POM ani BOM
+- **Zjištění:** Verze sdílených závislostí (`pdfbox`, `commons-io`, `org.json`, `solr-solrj`) jsou spravovány samostatně v `web/pom.xml` i `ThumbnailsGenerator/pom.xml`.
+- **Dopad:** Ruční synchronizace verzí; riziko nekonzistentních verzí při upgradu.
+- **Návrh:** Přidat root parent POM s `dependencyManagement` sekcí.
+
+### [T02] ThumbnailsGenerator cílí na Java 1.8
+- **Zjištění:** `maven.compiler.source/target = 1.8`, hlavní aplikace cílí na Java 17.
+- **Dopad:** Nekonzistentní runtime; Java 1.8 je EOL (bez bezpečnostních záplat od Oracle).
+- **Návrh:** Upgradovat na Java 17.
+
+### [T02] Duplicita HTTP klientů v main aplikaci
+- **Zjištění:** `org.apache.httpcomponents:httpclient:4.5.14` v Maven + `java.net.http` v kódu.
+- **Dopad:** Zbytečná závislost navyšuje WAR; dva různé paradigmaty HTTP komunikace.
+- **Návrh:** Standardizovat na `java.net.http`.
 
 ### [T01] Chybějící managed-schema pro Solr kolekci `oai`
 - **Zjištění:** `solr/oai/conf/` neobsahuje `managed-schema` (ostatní kolekce ho mají).
@@ -38,6 +73,26 @@
 ## Nízká priorita
 
 <!-- Kosmetické úpravy, dokumentace, minor code quality -->
+
+### [T02] Axios nadbytečný vedle Angular HttpClient
+- **Zjištění:** `axios:^1.11.0` v npm závislostech — duplicita s Angular HttpClient.
+- **Návrh:** Ověřit využití; migrovat na Angular HttpClient a odstranit axios.
+
+### [T02] Moment.js v maintenance mode
+- **Zjištění:** `moment:^2.30.1` — Moment.js je v maintenance mode od roku 2020.
+- **Návrh:** Migrovat na `date-fns` nebo nativní Angular `DatePipe`.
+
+### [T02] Version range pro thumbnailator
+- **Zjištění:** `net.coobird:thumbnailator:[0.4,0.5)` — nedeterministický build.
+- **Návrh:** Zafixovat konkrétní verzi (např. `0.4.20`).
+
+### [T02] @ngu/carousel verze pro Angular 20 v Angular 21 aplikaci
+- **Zjištění:** `@ngu/carousel:^20.0.1` — carousel pro Angular 20, aplikace je Angular 21.
+- **Návrh:** Upgradovat na verzi kompatibilní s Angular 21 nebo nahradit.
+
+### [T02] Duplicita path validation v ApiServlet a InitServlet
+- **Zjištění:** Obě třídy implementují vlastní normalizaci cest.
+- **Návrh:** Extrahovat do sdílené utility třídy `PathUtils`.
 
 ### [T01] Překlep v názvu Java balíčku: `imagging`
 - **Zjištění:** Balíček `cz.inovatika.arup.digiarchiv.web4.imagging` obsahuje překlep.

--- a/docs_agents/review_cache.json
+++ b/docs_agents/review_cache.json
@@ -8,7 +8,7 @@
       "completed_at": "2026-03-08",
       "report_path": "docs_agents/review_reports/T01.md"
     },
-    "T02": { "status": "pending", "completed_at": null, "report_path": null },
+    "T02": { "status": "done", "completed_at": "2026-03-08", "report_path": "docs_agents/review_reports/T02.md" },
     "T03": { "status": "pending", "completed_at": null, "report_path": null },
     "T04": { "status": "pending", "completed_at": null, "report_path": null },
     "T05": { "status": "pending", "completed_at": null, "report_path": null },
@@ -134,6 +134,16 @@
       "sha256": "1932378f8d32072a551b0cc928bd8948fc350626487713c1ee55263ec6e31847",
       "last_reviewed": "2026-03-08",
       "task_id": "T01"
+    },
+    "web/src/main/ng/package.json": {
+      "sha256": "4474b30437847ee844537edb586171a6c2edcc36e7bd7d0de7f0793a89a60585",
+      "last_reviewed": "2026-03-08",
+      "task_id": "T02"
+    },
+    "ThumbnailsGenerator/pom.xml": {
+      "sha256": "0135611dab53c88ec7ee94b8d0c2dde65ed1f3e7d023d9aa3354c411de18a9f2",
+      "last_reviewed": "2026-03-08",
+      "task_id": "T02"
     }
   }
 }

--- a/docs_agents/review_reports/T02.md
+++ b/docs_agents/review_reports/T02.md
@@ -1,0 +1,129 @@
+# T02 — Graf interních a externích závislostí
+
+**Datum:** 2026-03-08
+**Dotčené soubory:**
+- `web/pom.xml`
+- `ThumbnailsGenerator/pom.xml`
+- `web/src/main/ng/package.json`
+- `web/src/main/java/cz/inovatika/arup/digiarchiv/web4/` (všechny balíčky)
+
+---
+
+## 1. Shrnutí zjištění
+
+Repozitář obsahuje dva nezávislé Maven moduly (`web/` a `ThumbnailsGenerator/`) bez společného parent POM. Hlavní Java aplikace cílí na **Java 17 + Jakarta EE 11**, ThumbnailsGenerator na **Java 1.8** — nekonzistentní runtime. Frontend je Angular 21 s TypeScriptem ~5.9.3.
+
+Kritickým nálezem je **Saxon 8.7** (XSLT procesor z roku 2006) — použitý v Maven závislosti `net.sf.saxon:saxon:8.7`. Aktuální verze je Saxon-HE 12.x. Tato závislost je kriticky zastaralá (~18 let) a postrádá bezpečnostní záplaty. Přestože AGENTS.md uvádí XSLT 2.0/3.0 procesor, Saxon 8.7 má jen dílčí podporu XSLT 2.0 a XSLT 3.0 vůbec nepodporuje.
+
+Dalšími problémy jsou EOL závislost (Apache XML-RPC) a namespace nekompatibilita `javax.mail` v Jakarta EE 11 projektu.
+
+Architektonicky jsou patrné dvě **god třídy** přes 1000 řádků (`SolrSearcher`, `FedoraHarvester`) a těsná vazba na externí AMČR Fedora API.
+
+---
+
+## 2. Identifikované problémy
+
+### 2.1 Maven závislosti (`web/pom.xml`)
+
+| Závislost | Verze | Problém |
+|-----------|-------|---------|
+| `net.sf.saxon:saxon` | **8.7** (2006) | Kriticky zastaralé — chybí 18 let záplat; Saxon-HE 12.x je aktuální |
+| `org.apache.xmlrpc:xmlrpc-client` | 3.1.3 | EOL od 2016 — bez bezpečnostních aktualizací |
+| `javax.mail:mail` | 1.4.7 | Starý `javax.mail` namespace v Jakarta EE 11 projektu (očekává `jakarta.mail`) |
+| `org.apache.httpcomponents:httpclient` | 4.5.14 | HttpClient 4.x — projekt jinak používá `java.net.http` (JDK 11+); duplicita |
+
+### 2.2 ThumbnailsGenerator (`ThumbnailsGenerator/pom.xml`)
+
+| Problém | Detail |
+|---------|--------|
+| Java verze | Kompiluje na Java 1.8, hlavní app na Java 17 |
+| Range verze | `thumbnailator:[0.4,0.5)` — nedeterministický build |
+| Chybí parent POM | Sdílené verze (`pdfbox`, `commons-io`, `org.json`, `solr-solrj`) musí být synchronizovány ručně |
+
+### 2.3 npm závislosti (`package.json`)
+
+| Závislost | Problém |
+|-----------|---------|
+| `@ngu/carousel:^20.0.1` | Verze pro Angular 20, aplikace je Angular 21 — riziko nekompatibility |
+| `axios:^1.11.0` | Nadbytečný — duplicita s Angular HttpClient; zvyšuje bundle size |
+| `moment:^2.30.1` | Maintenance mode od 2020; doporučena migrace |
+| `leaflet.locationfilter:^0.1.0` | Verze 0.x, pravděpodobně neudržovaný projekt |
+
+### 2.4 Architektonické problémy — interní Java závislosti
+
+| Třída | Řádky | Problém |
+|-------|-------|---------|
+| `SolrSearcher` | 1 048 | God class — query building, access control, facety, thesaurus vše v jedné třídě |
+| `FedoraHarvester` | 1 024 | God class — Fedora komunikace, transformace, bulk indexace, error handling |
+| `SearchServlet` | 634 | Centrální servlet s 17+ Actions; těsná vazba na Solr a Fedoru |
+| `SearchUtils` | 344 | Masivní switch statements pro 12+ typů entit; měl by být factory/config driven |
+| `Options` | 276 | Singleton — globální mutable state; potenciální concurrency problémy |
+
+**Duplicita path validation logic:** `ApiServlet` i `InitServlet` obsahují vlastní implementaci bezpečné normalizace cest — měla by být extrahována do sdílené utility.
+
+---
+
+## 3. Návrhy zlepšení
+
+### Priorita Vysoká
+
+1. **Upgradovat Saxon 8.7 → Saxon-HE 12.x**
+   - Saxon-HE je open-source, zpětně kompatibilní pro XSLT 2.0
+   - Přidává plnou podporu XSLT 3.0 (odpovídá AGENTS.md)
+   - Změna v `pom.xml`: `net.sf.saxon:Saxon-HE:12.5`
+
+2. **Refaktoring god tříd**
+   - `SolrSearcher`: extrahovat access level logiku do `AccessLevelService`, thesaurus do `ThesaurusService`
+   - `FedoraHarvester`: extrahovat record-type handlers do Strategy implementací
+
+3. **Přidat Java testy** (evidováno v T01, opakováno pro prioritu)
+   - JUnit 5 pro `SearchUtils`, `SolrSearcher`, `FedoraUtils`, `IndexUtils`
+
+### Priorita Střední
+
+4. **Nahradit `javax.mail` za `jakarta.mail`**
+   - Přidat `jakarta.mail:jakarta.mail-api` + Angus Mail implementaci
+   - Nahradit `commons-email` za Jakarta Mail přímo nebo Eclipse Angus
+
+5. **Odstranit Apache XML-RPC (EOL)**
+   - Dohledat použití `xmlrpc-client` v kódu; nahradit `java.net.http`
+
+6. **Přidat root parent POM**
+   - Centralizovat verze sdílených závislostí (pdfbox, commons-io, org.json, solr-solrj)
+   - Eliminovat ruční synchronizaci verzí mezi `web/` a `ThumbnailsGenerator/`
+
+7. **Upgradovat ThumbnailsGenerator na Java 17**
+
+8. **Sjednotit HTTP klienty v `web/`**
+   - Odstranit `org.apache.httpcomponents:httpclient` a migrovat vše na `java.net.http`
+
+### Priorita Nízká
+
+9. **Odstranit/nahradit axios** za Angular HttpClient
+10. **Migrovat Moment.js** → date-fns nebo nativní Angular DatePipe
+11. **Zafixovat thumbnailator verzi** (místo range `[0.4,0.5)`)
+12. **Extrahovat path normalization** z ApiServlet a InitServlet do sdílené utility
+
+---
+
+## 4. Odhad náročnosti refaktoringu
+
+| Oblast | Náročnost | Priorita |
+|--------|-----------|----------|
+| Saxon upgrade (pom.xml + ověření XSLT) | M | 1 |
+| Refaktoring SolrSearcher | L | 2 |
+| Refaktoring FedoraHarvester | L | 2 |
+| javax.mail → jakarta.mail | S | 3 |
+| Odstranění XML-RPC | S | 3 |
+| Root parent POM | S | 3 |
+| ThumbnailsGenerator Java 17 upgrade | S | 3 |
+| HTTP klient sjednocení | M | 4 |
+| Java testy (nové) | XL | 1 |
+| axios → Angular HttpClient | M | 4 |
+| Moment.js migrace | M | 5 |
+
+---
+
+## 5. Návrhy na zlepšení promptu
+
+Viz `docs_agents/prompt_evolution/T02_prompt_update.md`.


### PR DESCRIPTION
## Summary

This PR adds a comprehensive analysis of internal and external dependencies for the AMČR digital archive project, including Maven, npm, and architectural dependency mappings. The analysis identifies critical issues with outdated dependencies and architectural problems that need to be addressed.

## Key Changes

- **New dependency graph document** (`docs_agents/dependency_graph.json`): Comprehensive 400-line JSON document mapping:
  - Java package structure with 6 main packages (root, fedora, fedora.models, index, imaging, oai)
  - Key classes with line counts and identified issues (god classes: SolrSearcher 1048 LOC, FedoraHarvester 1024 LOC)
  - Maven dependencies with 16 compile-scope artifacts and identified concerns
  - npm dependencies (Angular 21, TypeScript 5.9.3) with 25 production packages
  - External service dependencies (AMČR API, Solr, Fedora Repository, Google reCAPTCHA)
  - 10 architectural issues with severity levels and recommendations

- **New review report** (`docs_agents/review_reports/T02.md`): Detailed findings including:
  - Critical Saxon 8.7 XSLT processor (from 2006) requiring upgrade to Saxon-HE 12.x
  - Namespace incompatibility: `javax.mail` in Jakarta EE 11 project (should be `jakarta.mail`)
  - EOL dependency: Apache XML-RPC (end-of-life since 2016)
  - ThumbnailsGenerator targeting Java 1.8 while main app targets Java 17
  - God class refactoring recommendations for SolrSearcher and FedoraHarvester
  - Redundant HTTP clients (axios + Angular HttpClient)
  - Maintenance-mode dependencies (Moment.js)

- **Updated refactoring backlog** (`docs_agents/refactoring_backlog.md`): Added 12 new items from T02 analysis organized by priority (High, Medium, Low)

- **New prompt evolution document** (`docs_agents/prompt_evolution/T02_prompt_update.md`): Recommendations for improving future analysis prompts

- **Updated bugs tracking** (`docs_agents/bugs.md`): Added 2 critical bugs:
  - BUG-001: Saxon 8.7 security risk
  - BUG-002: javax.mail namespace incompatibility

- **Updated review cache** (`docs_agents/review_cache.json`): Marked T02 as completed

## Notable Implementation Details

- Identified 10 architectural issues ranging from high to low severity
- Mapped internal Java dependencies showing tight coupling between SolrSearcher, FedoraHarvester, and external AMČR API
- Documented version inconsistencies between web module (Java 17) and ThumbnailsGenerator (Java 1.8)
- Highlighted missing parent POM causing manual version synchronization of shared dependencies
- Provided specific upgrade paths and refactoring strategies for each identified issue

https://claude.ai/code/session_012bGwphexe4eDUmkr4gLaQV